### PR TITLE
Add colors to dimension contracts

### DIFF
--- a/.github/workflows/release_dev_branch.yml
+++ b/.github/workflows/release_dev_branch.yml
@@ -1,7 +1,10 @@
 # Orchestrator workflow that runs on every push to dev. It runs tests and then
 # python-semantic-release, which inspects conventional-commit messages on dev
 # and creates a new version commit + tag if appropriate. The PSR commit message
-# carries [skip ci] to prevent re-triggering this workflow.
+# carries the custom marker [skip release], checked below to prevent
+# re-triggering this workflow on PSR's own bump commits. We avoid GitHub's
+# built-in [skip ci] token because that would also suppress check_pr_main on
+# dev to main PRs whose head is the bump commit.
 name: Release Dev Branch
 
 on:
@@ -12,11 +15,12 @@ on:
 
 jobs:
     test_and_coverage:
+        if: ${{ !contains(github.event.head_commit.message || '', '[skip release]') }}
         uses: ./.github/workflows/test_and_coverage.yml
 
     release:
         needs: test_and_coverage
-        if: success()
+        if: ${{ success() && !contains(github.event.head_commit.message || '', '[skip release]') }}
         uses: ./.github/workflows/versioning.yml
         permissions:
             contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # CHANGELOG
 
+## v0.9.0 (2026-05-08)
+
+### Features
+
+
+- **Add colors** ([`b060520`](https://github.com/sweet-cross/crosscontract/commit/b060520a890513f102099fc0e2fb7009848bc477))
+
+  ## Pull request overview
+
+  Adds optional `color` support to dimension contracts across the schema template, registry dimension wrappers, tests, and documentation to enable downstream visualization use-cases (e.g., plotting).
+
+  **Changes:**
+  - Extend the rigid `DimensionSchema` template with an optional `color` field (hex format constraints) and document it.
+  - Add `color_map` to registry-side dimension variables, mirroring `label_map` behavior and introducing caching.
+  - Add/extend tests to include the `color` field in dimension fixtures and verify `color_map` behavior.
+
+  ### Reviewed changes
+
+  Copilot reviewed 5 out of 5 changed files in this pull request and generated 4 comments.
+
+  <details> <summary>Show a summary per file</summary>
+
+  | File | Description | | ---- | ----------- | | src/crosscontract/registry/variables/base_dimension.py | Adds cached `color_map` accessor and clears its cache alongside existing caches. | | src/crosscontract/contracts/schema/subschemas/dimension.py | Adds `color` field to the rigid Dimension schema template and updates its docstring. | | src/tests/registry/test_dimensions.py | Updates dimension test fixtures to include `color` and adds a new `TestColorMap` suite. | | src/tests/contracts/schema/subschemas/test_dimension_schema.py | Verifies `color` is present in schema fields when loading a Dimension contract from YAML. | | docs/contracts/contract_types.md | Updates Dimension contract documentation to include `color` in the field list (table format). | </details>
+
+
+
+
+
 ## v0.8.7 (2026-04-28)
 
 ### Bug fixes

--- a/docs/contracts/contract_types.md
+++ b/docs/contracts/contract_types.md
@@ -53,30 +53,14 @@ by adding specific constraints and conventions for dimension tables.
 
 Dimensions have the following fields:
 
-- "id":
-    - A unique identifier for each entry in the dimension table.
-    - required
-    - Type: string (max length 100 characters). Only letters (a-z, A-Z), numbers
-        and underscores are allowed. Must start with a letter.
-    - Constraints: Must be unique across the entire table and serves as the
-                    primary key.
-- "parent_id":
-    - A reference to the "id" of the parent entry in the same table
-    - optional (required for levels > 0)
-    - Type: string (max length 100 characters)
-- "level":
-    - Indicates the hierarchy level of the dimension, starting at 0 for the top level.
-    - required
-    - Type: integer (non-negative, >= 0)
-- "label":
-    - A human-readable label for the dimension entry. This is the default fallback
-        label for plotting etc purposes if no other label is provided.
-    - optional
-    - Type: string (max length 255 characters)
-- "description":
-    - A detailed description of the dimension entry.
-    - optional
-    - Type: string
+| Field | Required | Data Type | Description & Constraints |
+| :--- | :--- | :--- | :--- |
+| `id` | Yes | String (max 100 chars) | A unique identifier for each entry in the dimension table. Only letters (a-z, A-Z), numbers, and underscores are allowed. Must start with a letter. <br><br>**Constraint:** Must be unique across the entire table and serves as the primary key. |
+| `parent_id` | Optional* <br>*\* Required for levels > 0* | String (max 100 chars) | A reference to the `id` of the parent entry in the same table.|
+| `level` | Yes | Integer (>= 0) | Indicates the hierarchy level of the dimension, starting at `0` for the top level. |
+| `label` | Optional | String (max 255 chars) | A human-readable label for the dimension entry. This is the default fallback label for plotting and other purposes if no other label is provided. |
+| `description` | Optional | String | A detailed description of the dimension entry. |
+| `color` | Optional | String | A hex color that can be used for plotting in stacked bar charts. |
 
 At the data level, dimensions receive more checks to ensure the hierarchy is
 consistent and valid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ major_on_zero = false
 allow_zero_version = true
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/crosscontract/__init__.py:__version__"]
-commit_message = "{version}\n\n[skip ci]"
+commit_message = "{version}\n\n[skip release]"
 
 # PSR v8+ uses release groups. Override the default "main" group (which would
 # otherwise match the `(main|master)` regex) so the release branch is `dev`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crosscontract"
-version = "0.8.7"
+version = "0.9.0"
 description = "Provides data contracts with frictionless schemas and client to interact with CROSS data platform.   "
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/crosscontract/__init__.py
+++ b/src/crosscontract/__init__.py
@@ -4,7 +4,7 @@ from .contracts import BaseContract, CrossContract, SchemaValidationError, Table
 from .crossclient import CrossClient
 from .registry import CrossRegistry
 
-__version__ = "0.8.7"
+__version__ = "0.9.0"
 
 __all__ = [
     "CrossClient",

--- a/src/crosscontract/contracts/schema/subschemas/dimension.py
+++ b/src/crosscontract/contracts/schema/subschemas/dimension.py
@@ -54,6 +54,12 @@ DIMENSION_SCHEMA_TEMPLATE = {
             "type": "string",
             "description": "Description of a single element",
         },
+        {
+            "name": "color",
+            "type": "string",
+            "description": "Color associated with the dimension entry",
+            "constraints": {"maxLength": 7, "pattern": r"^#(?:[0-9a-fA-F]{3}){1,2}$"},
+        },
     ],
 }
 
@@ -96,6 +102,11 @@ class DimensionSchema(BaseDimensionSchema):
         - optional
         - Type: string
         - Description: A detailed description of the dimension entry.
+    - "color":
+        - optional
+        - Type: string (must be a valid hex color code, e.g., "#RRGGBB")
+        - Description: A color associated with the dimension entry, which can be
+                       used for visualization purposes.
 
     At the data level, dimensions receive more checks to ensure the hierarchy is
     consistent and valid.

--- a/src/crosscontract/registry/variables/base_dimension.py
+++ b/src/crosscontract/registry/variables/base_dimension.py
@@ -1,5 +1,7 @@
 from abc import ABC
 
+import pandas as pd
+
 from crosscontract.crossclient.services import ContractResource
 
 from .base_variable import CrossBaseVariable
@@ -18,6 +20,7 @@ class CrossBaseDimension(CrossBaseVariable, ABC):
     def __init__(self, contract_resource: ContractResource):
         super().__init__(contract_resource)
         self._label_map: dict[str, str] | None = None
+        self._color_map: dict[str, str] | None = None
 
     @property
     def label_map(self) -> dict[str, str]:
@@ -28,6 +31,24 @@ class CrossBaseDimension(CrossBaseVariable, ABC):
             self._label_map = dict(zip(df[id_field], df["label"], strict=True))
         return self._label_map.copy()
 
+    @property
+    def color_map(self) -> dict[str, str]:
+        """Mapping from primary-key value to ``color`` for the dimension.
+
+        If the dimension doesn't have a color field, returns an empty dict.
+        """
+        df = self.data
+        if "color" not in df.columns:
+            return {}
+        if self._color_map is None:
+            id_field = self.contract_resource.contract.tableschema.primaryKey.root[0]
+            self._color_map = dict(zip(df[id_field], df["color"], strict=True))
+        # filter out empty/null colors
+        return {
+            k: v for k, v in self._color_map.items() if not pd.isna(v) and v != ""
+        }  # filter out empty/null colors
+
     def clear_data_cache(self):
         super().clear_data_cache()
         self._label_map = None
+        self._color_map = None

--- a/src/tests/contracts/schema/subschemas/test_dimension_schema.py
+++ b/src/tests/contracts/schema/subschemas/test_dimension_schema.py
@@ -85,3 +85,6 @@ class TestContractFromYAML:
 
         assert contract.tableschema.table_type == "Dimension"
         assert contract.tableschema.primaryKey.root == ["id"]
+        schema_fields = {field.name for field in contract.tableschema.fields}
+        for key in ["id", "parent_id", "level", "label", "description", "color"]:
+            assert key in schema_fields

--- a/src/tests/registry/test_dimensions.py
+++ b/src/tests/registry/test_dimensions.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -26,6 +27,7 @@ dim_contract = {
             {"name": "label", "type": "string"},
             {"name": "level", "type": "integer"},
             {"name": "parent_id", "type": "string"},
+            {"name": "color", "type": "string"},
         ],
     },
 }
@@ -36,6 +38,7 @@ dim_data = pd.DataFrame(
         "label": ["Total", "Category A", "Category B", "Leaf 1", "Leaf 2", "Leaf 3"],
         "level": [0, 1, 1, 2, 2, 2],
         "parent_id": [None, "total", "total", "cat_a", "cat_a", "cat_b"],
+        "color": ["#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#00FFFF"],
     }
 )
 
@@ -79,6 +82,48 @@ class TestLabelMap:
         map2 = dimension.label_map
         assert map1 == map2
         assert map1 is not map2  # copies returned
+
+
+class TestColorMap:
+    def test_all_colors_mapped(self, dimension: CrossDimension):
+        color_map = dimension.color_map
+        assert set(color_map.keys()) == set(dim_data["id"])
+        for k, v in color_map.items():
+            assert v == dim_data.loc[dim_data["id"] == k, "color"].iloc[0]
+
+    def test_color_map_cached(self, dimension: CrossDimension):
+        map1 = dimension.color_map
+        map2 = dimension.color_map
+        assert map1 == map2
+        assert map1 is not map2  # copies returned
+
+    def test_no_color_column(self, make_contract_resource):
+        contract = {
+            "name": "dim_no_color",
+            "description": "Dimension without color column",
+            "title": "No Color",
+            "tableschema": {
+                "primaryKey": ["id"],
+                "fields": [
+                    {"name": "id", "type": "string"},
+                    {"name": "label", "type": "string"},
+                    {"name": "level", "type": "integer"},
+                    {"name": "parent_id", "type": "string"},
+                ],
+            },
+        }
+        data = dim_data.drop(columns=["color"])
+        cr = make_contract_resource(data=data, contract_dict=contract)
+        dim = CrossDimension(contract_resource=cr)
+        assert dim.color_map == {}
+
+    @pytest.mark.parametrize("empty_value", ["", None, pd.NA, np.nan])
+    def test_empty_color_values(self, make_contract_resource, empty_value):
+        data = dim_data.copy()
+        data["color"] = empty_value  # empty color values
+        cr = make_contract_resource(data=data, contract_dict=dim_contract)
+        dim = CrossDimension(contract_resource=cr)
+        assert dim.color_map == {}
 
 
 class TestAncestorMaps:


### PR DESCRIPTION
Allow colors in dimension contract. In the registry, dimensions have color_map property that allows to get the color by element.