### PR TITLE
chore: replace [skip ci] with custom [skip release] marker

### DIFF
--- a/.github/workflows/release_dev_branch.yml
+++ b/.github/workflows/release_dev_branch.yml
@@ -1,7 +1,10 @@
 # Orchestrator workflow that runs on every push to dev. It runs tests and then
 # python-semantic-release, which inspects conventional-commit messages on dev
 # and creates a new version commit + tag if appropriate. The PSR commit message
-# carries [skip ci] to prevent re-triggering this workflow.
+# carries the custom marker [skip release], checked below to prevent
+# re-triggering this workflow on PSR's own bump commits. We avoid GitHub's
+# built-in [skip ci] token because that would also suppress check_pr_main on
+# dev to main PRs whose head is the bump commit.
 name: Release Dev Branch
 
 on:
@@ -12,11 +15,12 @@ on:
 
 jobs:
     test_and_coverage:
+        if: ${{ !contains(github.event.head_commit.message || '', '[skip release]') }}
         uses: ./.github/workflows/test_and_coverage.yml
 
     release:
         needs: test_and_coverage
-        if: success()
+        if: ${{ success() && !contains(github.event.head_commit.message || '', '[skip release]') }}
         uses: ./.github/workflows/versioning.yml
         permissions:
             contents: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ major_on_zero = false
 allow_zero_version = true
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/crosscontract/__init__.py:__version__"]
-commit_message = "{version}\n\n[skip ci]"
+commit_message = "{version}\n\n[skip release]"
 
 # PSR v8+ uses release groups. Override the default "main" group (which would
 # otherwise match the `(main|master)` regex) so the release branch is `dev`.


### PR DESCRIPTION
GitHub's [skip ci] token suppresses both push and pull_request workflow runs whose head commit carries it. That broke check_pr_main on dev to main PRs whose head was the PSR version-bump commit.

Switch to a custom [skip release] marker that PSR writes into its bump commit message and that release_dev_branch.yml explicitly checks. GitHub does not recognize this token, so dev to main PRs run check_pr_main normally, but Release Dev Branch still skips itself on PSR's own commits and avoids re-running the full test matrix.